### PR TITLE
Convert symbol to a string

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -6,5 +6,6 @@ MRuby::Build.new do |conf|
   conf.gem mgem: 'mruby-thread'
   conf.linker.libraries << ['pthread']
   conf.gem File.expand_path(File.dirname(__FILE__))
+  conf.cc.flags << "-DMRB_THREAD_COPY_VALUES"
   conf.enable_test
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,6 +1,7 @@
 MRuby::Gem::Specification.new('mruby-signal-thread') do |spec|
   spec.license = 'MIT'
   spec.authors = 'pyama86'
+  spec.cc.flags << "-DMRB_THREAD_COPY_VALUES"
   spec.add_dependency 'mruby-thread'
   spec.add_test_dependency 'mruby-process'
   spec.add_test_dependency 'mruby-sleep'

--- a/mrblib/mrb_signalthread.rb
+++ b/mrblib/mrb_signalthread.rb
@@ -1,8 +1,9 @@
 class SignalThread
   def self.trap(sig, &block)
-    mask(sig)
+    strsig = sig.to_s
+    mask(strsig)
     pr = Proc.new do
-      wait(sig) do
+      wait(strsig) do
         block.call
       end
     end


### PR DESCRIPTION
It seems that the symbol table may be corrupted when running with multi-thread

```ruby
 SignalThread.trap(:USR1) do
    puts 'ok'
 end
```

```gdb
Thread 17 "mrbtest" hit Breakpoint 2, trap_signm (mrb=0x795dc0,
vsig=...)
    at
    /home/pyama/src/github.com/matsumotory/mruby-timer-thread/mruby/build/mrbgems/mruby-signal-thread/src/mrb_signalthread.c:208
    208         if (memcmp("SIG", s, 3) == 0)
    (gdb) p s
    $13 = 0x4dc3b2 <gem_mrblib_irep_mruby_enum_lazy+214> "Lazy"
# The value you want is `USR1`
```
Perhaps `mrb-> symtbl` is broken somewhere.