### PR TITLE
fix race condition

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -2,6 +2,7 @@ MRuby::Gem::Specification.new('mruby-signal-thread') do |spec|
   spec.license = 'MIT'
   spec.authors = 'pyama86'
   spec.add_dependency 'mruby-thread'
+  spec.add_dependency 'mruby-mutex'
   spec.add_test_dependency 'mruby-process'
   spec.add_test_dependency 'mruby-sleep'
 end

--- a/mrblib/mrb_signalthread.rb
+++ b/mrblib/mrb_signalthread.rb
@@ -1,8 +1,11 @@
 class SignalThread
   def self.trap(sig, &block)
+    m = Mutex.new # :global => true
+    m.lock
     mask(sig)
     pr = Proc.new do
       wait(sig) do
+        m.unlock
         block.call
       end
     end

--- a/src/mrb_signalthread.c
+++ b/src/mrb_signalthread.c
@@ -26,6 +26,8 @@ static const struct signals {
   const char *signm;
   int signo;
 } siglist[] = {{"EXIT", 0},
+
+
 #ifdef SIGHUP
                {"HUP", SIGHUP},
 #endif


### PR DESCRIPTION
If a signal gets flying before masking and waiting, it gets illegal movement.

refs:https://github.com/matsumotory/mruby-timer-thread/pull/1