### PR TITLE
support pthread_kill

### DIFF
--- a/mrblib/mrb_signalthread.rb
+++ b/mrblib/mrb_signalthread.rb
@@ -1,4 +1,4 @@
-class SignalThread
+class SignalThread < Thread
   def self.trap(sig, &block)
     strsig = sig.to_s
     mask(strsig)
@@ -8,8 +8,12 @@ class SignalThread
       end
     end
 
-    Thread.new(pr) do |pr|
+    self.new(pr) do |pr|
       pr.call
     end
+  end
+
+  def kill(sig)
+    _kill(sig.to_s)
   end
 end

--- a/test/mrb_signalthread.rb
+++ b/test/mrb_signalthread.rb
@@ -16,3 +16,15 @@ assert('SignalThread#trap') do
   sleep 1
   a == 3
 end
+
+assert('SignalThread#kill') do
+  a = 1
+  th = SignalThread.trap(:HUP) do
+    a = 2
+  end
+
+  th.alive?
+  th.kill :HUP
+  sleep 1
+  a == 2
+end


### PR DESCRIPTION
Previously there was a problem that it was not possible to process multiple patterns of signals.
It made it possible to send a signal directly to thread.

```ruby
th1 = SignalThread.trap(:USR1) do
  puts "signal1"
end

th2 = SignalThread.trap(:USR1) do
  puts "signal2"
end

Process.kill :USR1, Process.pid
sleep 1
th1.kill :USR1
sleep 1
th2.kill :USR1
sleep 1
```

```bash
mruby/bin/mruby example/example.rb
signal1
signal1
signal2
```