### PR TITLE
More feature support about signal :gem:

### DIFF
--- a/mrblib/mrb_signalthread.rb
+++ b/mrblib/mrb_signalthread.rb
@@ -13,6 +13,17 @@ class SignalThread < Thread
     end
   end
 
+  def self.trap_once(sig, &block)
+    strsig = sig.to_s
+    mask(strsig)
+    pr = block
+
+    Thread.new(strsig, pr) do |strsig, pr|
+      wait(strsig)
+      pr.call
+    end
+  end
+
   def kill(sig)
     _kill(sig.to_s)
   end

--- a/mrblib/mrb_signalthread.rb
+++ b/mrblib/mrb_signalthread.rb
@@ -16,10 +16,12 @@ class SignalThread < Thread
   def self.trap_once(sig, &block)
     strsig = sig.to_s
     mask(strsig)
-    pr = block
-
-    Thread.new(strsig, pr) do |strsig, pr|
+    pr = Proc.new do
       wait(strsig)
+      block.call
+    end
+
+    self.new(pr) do |pr|
       pr.call
     end
   end

--- a/mrblib/mrb_signalthread.rb
+++ b/mrblib/mrb_signalthread.rb
@@ -1,25 +1,40 @@
 class SignalThread < Thread
-  def self.trap(sig, &block)
+  def self.trap(sig, options={}, &block)
     strsig = sig.to_s
     mask(strsig)
-    pr = Proc.new do
-      wait(strsig) do
-        block.call
-      end
-    end
+    pr = if options[:detailed]
+           Proc.new do
+             SignalThread.waitinfo(strsig) do |info|
+               block.call(info)
+             end
+           end
+         else
+           Proc.new do
+             SignalThread.wait(strsig) do
+               block.call
+             end
+           end
+         end
 
     self.new(pr) do |pr|
       pr.call
     end
   end
 
-  def self.trap_once(sig, &block)
+  def self.trap_once(sig, options={}, &block)
     strsig = sig.to_s
     mask(strsig)
-    pr = Proc.new do
-      wait(strsig)
-      block.call
-    end
+    pr = if options[:detailed]
+           Proc.new do
+             info = SignalThread.waitinfo(strsig)
+             block.call(info)
+           end
+         else
+           Proc.new do
+             SignalThread.wait(strsig)
+             block.call
+           end
+         end
 
     self.new(pr) do |pr|
       pr.call

--- a/test/mrb_signalthread.rb
+++ b/test/mrb_signalthread.rb
@@ -20,10 +20,10 @@ end
 assert('SignalThread#trap with RTSignal') do
   begin
     a = 0
-    SignalThread.trap(:RT1) do
+    t = SignalThread.trap(:RT1) do
       a = 10
     end
-    SignalThread.queue Process.pid, :RT1
+    t.kill :RT1
     usleep 1000
     assert_true a == 10
   rescue ArgumentError => e

--- a/test/mrb_signalthread.rb
+++ b/test/mrb_signalthread.rb
@@ -31,6 +31,18 @@ assert('SignalThread#trap with RTSignal') do
   end
 end
 
+assert('SignalThread#trap_once') do
+  a = 1
+  t = SignalThread.trap_once(:USR1) do
+    a = 4
+  end
+
+  t.kill :USR1
+  usleep 1000
+  assert_equal 4, a
+  assert_false t.alive?
+end
+
 assert('SignalThread#thread_id') do
   a = 1
   th = SignalThread.trap(:HUP) do

--- a/test/mrb_signalthread.rb
+++ b/test/mrb_signalthread.rb
@@ -43,6 +43,17 @@ assert('SignalThread#trap_once') do
   assert_false t.alive?
 end
 
+assert('SignalThread#trap, detailed: true') do
+  name = nil
+  t = SignalThread.trap(:USR2, detailed: true) do |info|
+    name = info.class.to_s
+  end
+
+  t.kill :USR2
+  usleep 1000
+  assert_equal "SigInfo", name
+end
+
 assert('SignalThread#thread_id') do
   a = 1
   th = SignalThread.trap(:HUP) do


### PR DESCRIPTION
Hi, nice guy!

I added 2 features:

* `SignalThread.trap_once` - Just trap a signal once, and then thread will die.
* `detailed: true` - Get signal information using `siginfo_t` and `sigwaitinfo(2)`


Here is a detailed signal info image:

```ruby
> i = nil
 => nil
> t = SignalThread.trap(:USR2, detailed: true) {|info| i = info }
 => #<SignalThread:0x17a4980>
> t.kill :USR2
 => nil
> i
 => #<SigInfo:0x1823cd0>
> i.pid # Signal sender
 => 18548
> i.uid # UNIX user id who sent signal
 => 1000
> i.syscall # This is useful with mruby-seccomp
 => 0
```

Excuse: the `detailed: true` test behaves a bit weird in mrbtest multi-threaded environment. This is experimental.