### PR TITLE
Drain exception on threads

### DIFF
--- a/src/mrb_signalthread.c
+++ b/src/mrb_signalthread.c
@@ -374,6 +374,22 @@ static mrb_value mrb_signal_thread_waitinfo(mrb_state *mrb, mrb_value self)
   }
 }
 
+static mrb_value mrb_signal_thread_get_value_context(mrb_state *mrb, mrb_value self)
+{
+  mrb_value value_context = mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "context"));
+
+  if (mrb_nil_p(value_context)) {
+    mrb_raise(mrb, E_TYPE_ERROR, "context instance is nil");
+  }
+
+  if (strcmp(DATA_TYPE(value_context)->struct_name, "mrb_thread_context") != 0) {
+    mrb_raisef(mrb, E_TYPE_ERROR, "wrong argument type %S (expected mrb_thread_context)",
+               mrb_str_new_cstr(mrb, DATA_TYPE(value_context)->struct_name));
+  }
+
+  return value_context;
+}
+
 static mrb_value mrb_signal_thread_kill(mrb_state *mrb, mrb_value self)
 {
   int sig;
@@ -388,15 +404,7 @@ static mrb_value mrb_signal_thread_kill(mrb_state *mrb, mrb_value self)
 
   sig = trap_signm(mrb, argv[0]);
 
-  value_context = mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "context"));
-  if (mrb_nil_p(value_context))
-    mrb_raise(mrb, E_TYPE_ERROR, "context instance is nil");
-
-  if (strcmp(DATA_TYPE(value_context)->struct_name, "mrb_thread_context") != 0) {
-    mrb_raisef(mrb, E_TYPE_ERROR, "wrong argument type %S (expected mrb_thread_context)",
-               mrb_str_new_cstr(mrb, DATA_TYPE(value_context)->struct_name));
-  }
-
+  value_context = mrb_signal_thread_get_value_context(mrb, self);
   context = DATA_PTR(value_context);
   if (context->mrb == NULL)
     return mrb_nil_value();
@@ -408,16 +416,7 @@ static mrb_value mrb_signal_thread_kill(mrb_state *mrb, mrb_value self)
 static mrb_value mrb_signal_thread_thread_id(mrb_state *mrb, mrb_value self)
 {
   mrb_thread_context *context = NULL;
-  mrb_value value_context = mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "context"));
-
-  if (mrb_nil_p(value_context)) {
-    mrb_raise(mrb, E_TYPE_ERROR, "context instance is nil");
-  }
-
-  if (strcmp(DATA_TYPE(value_context)->struct_name, "mrb_thread_context") != 0) {
-    mrb_raisef(mrb, E_TYPE_ERROR, "wrong argument type %S (expected mrb_thread_context)",
-               mrb_str_new_cstr(mrb, DATA_TYPE(value_context)->struct_name));
-  }
+  mrb_value value_context = mrb_signal_thread_get_value_context(mrb, self);
 
   context = DATA_PTR(value_context);
   if (context->mrb == NULL) {
@@ -443,17 +442,7 @@ static mrb_value mrb_signal_thread_kill_by_thread_id(mrb_state *mrb, mrb_value s
 static mrb_value mrb_signal_thread_is_failed(mrb_state *mrb, mrb_value self)
 {
   mrb_thread_context *context = NULL;
-  mrb_value value_context = mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "context"));
-
-  if (mrb_nil_p(value_context)) {
-    mrb_raise(mrb, E_TYPE_ERROR, "context instance is nil");
-  }
-
-  if (strcmp(DATA_TYPE(value_context)->struct_name, "mrb_thread_context") != 0) {
-    mrb_raisef(mrb, E_TYPE_ERROR, "wrong argument type %S (expected mrb_thread_context)",
-               mrb_str_new_cstr(mrb, DATA_TYPE(value_context)->struct_name));
-  }
-
+  mrb_value value_context = mrb_signal_thread_get_value_context(mrb, self);
   context = DATA_PTR(value_context);
   if (context->mrb == NULL) {
     return mrb_nil_value();
@@ -465,19 +454,10 @@ static mrb_value mrb_signal_thread_is_failed(mrb_state *mrb, mrb_value self)
 static mrb_value mrb_signal_thread_exception(mrb_state *mrb, mrb_value self)
 {
   mrb_thread_context *context = NULL;
-  mrb_value value_context = mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "context"));
+  mrb_value value_context = mrb_signal_thread_get_value_context(mrb, self);
   mrb_value is_failed = mrb_funcall(mrb, self, "failed?", 0);
   if (!mrb_bool(is_failed)) {
     return mrb_nil_value();
-  }
-
-  if (mrb_nil_p(value_context)) {
-    mrb_raise(mrb, E_TYPE_ERROR, "context instance is nil");
-  }
-
-  if (strcmp(DATA_TYPE(value_context)->struct_name, "mrb_thread_context") != 0) {
-    mrb_raisef(mrb, E_TYPE_ERROR, "wrong argument type %S (expected mrb_thread_context)",
-               mrb_str_new_cstr(mrb, DATA_TYPE(value_context)->struct_name));
   }
 
   context = DATA_PTR(value_context);

--- a/src/mrb_signalthread.c
+++ b/src/mrb_signalthread.c
@@ -440,6 +440,28 @@ static mrb_value mrb_signal_thread_kill_by_thread_id(mrb_state *mrb, mrb_value s
   return mrb_fixnum_value(pthread_kill((pthread_t)thread_id, sig));
 }
 
+static mrb_value mrb_signal_thread_is_failed(mrb_state *mrb, mrb_value self)
+{
+  mrb_thread_context *context = NULL;
+  mrb_value value_context = mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "context"));
+
+  if (mrb_nil_p(value_context)) {
+    mrb_raise(mrb, E_TYPE_ERROR, "context instance is nil");
+  }
+
+  if (strcmp(DATA_TYPE(value_context)->struct_name, "mrb_thread_context") != 0) {
+    mrb_raisef(mrb, E_TYPE_ERROR, "wrong argument type %S (expected mrb_thread_context)",
+               mrb_str_new_cstr(mrb, DATA_TYPE(value_context)->struct_name));
+  }
+
+  context = DATA_PTR(value_context);
+  if (context->mrb == NULL) {
+    return mrb_nil_value();
+  }
+
+  return mrb_bool_value((mrb_bool)(!context->alive && mrb_type(context->result) == MRB_TT_EXCEPTION));
+}
+
 #ifdef __APPLE__
 static int sigqueue(pid_t pid, int sig, const union sigval value)
 {
@@ -479,6 +501,7 @@ void mrb_mruby_signal_thread_gem_init(mrb_state *mrb)
 
   mrb_define_method(mrb, signalthread, "_kill", mrb_signal_thread_kill, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, signalthread, "thread_id", mrb_signal_thread_thread_id, MRB_ARGS_NONE());
+  mrb_define_method(mrb, signalthread, "failed?", mrb_signal_thread_is_failed, MRB_ARGS_NONE());
 
   mrb_define_class_method(mrb, signalthread, "queue", mrb_signal_thread_queue, MRB_ARGS_REQ(2));
 

--- a/test/mrb_signalthread_fail.rb
+++ b/test/mrb_signalthread_fail.rb
@@ -1,0 +1,20 @@
+assert('SignalThread#failed') do
+  t = SignalThread.new { 1 + 1 }
+  usleep 10 * 1000
+  assert_false t.failed?
+
+  t = SignalThread.new { raise "Something" }
+  usleep 10 * 1000
+  assert_true t.failed?
+
+  t = SignalThread.new { nomethod }
+  usleep 10 * 1000
+  assert_true t.failed?
+end
+
+assert('SignalThread#exception') do
+  t = SignalThread.new { raise "Something" }
+  usleep 10 * 1000
+  assert_equal "RuntimeError", t.exception.class.to_s
+  assert_equal "Something", t.exception.message
+end


### PR DESCRIPTION
Hi..... Nice (ry

I added the exception attribute, which have killed the thread it was born.

When mruby-signal-thread got unhandled exceptions, it dies silently, but the error information should be required in some cases.