### PR TITLE
Add SignalThread#cancel to just cancel

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -3,6 +3,7 @@ MRuby::Gem::Specification.new('mruby-signal-thread') do |spec|
   spec.authors = 'pyama86'
   spec.cc.flags << "-DMRB_THREAD_COPY_VALUES"
   spec.add_dependency 'mruby-thread'
+  spec.add_test_dependency 'mruby-time'
   spec.add_test_dependency 'mruby-process'
   spec.add_test_dependency 'mruby-sleep'
 end

--- a/test/mrb_signalthread_cancel.rb
+++ b/test/mrb_signalthread_cancel.rb
@@ -1,0 +1,10 @@
+assert("SignalThread#cancel") do
+  start = Time.now.to_f
+  t = SignalThread.new { sleep 10 }
+  v = t.cancel
+  t.join if t.alive?
+  fin = Time.now.to_f
+
+  assert_true (fin - start) < 1.0
+  assert_equal :canceled, v
+end


### PR DESCRIPTION
We now have `SignalThread#kill` to send any kind of signals to a thread.

I want to support `pthread_cancel` when just need to cancel the thread execution, regardless of signals.