### PR TITLE
Simplify thread creation

### DIFF
--- a/mrblib/mrb_signalthread.rb
+++ b/mrblib/mrb_signalthread.rb
@@ -2,42 +2,38 @@ class SignalThread < Thread
   def self.trap(sig, options={}, &block)
     strsig = sig.to_s
     mask(strsig)
-    pr = if options[:detailed]
-           Proc.new do
-             SignalThread.waitinfo(strsig) do |info|
-               block.call(info)
-             end
-           end
-         else
-           Proc.new do
-             SignalThread.wait(strsig) do
-               block.call
-             end
-           end
-         end
 
-    self.new(pr) do |pr|
-      pr.call
+    if options[:detailed]
+      self.new(block) do |pr|
+        while true
+          info = SignalThread.waitinfo(strsig)
+          pr.call(info)
+        end
+      end
+    else
+      self.new(block) do |pr|
+        while true
+          SignalThread.wait(strsig)
+          pr.call
+        end
+      end
     end
   end
 
   def self.trap_once(sig, options={}, &block)
     strsig = sig.to_s
     mask(strsig)
-    pr = if options[:detailed]
-           Proc.new do
-             info = SignalThread.waitinfo(strsig)
-             block.call(info)
-           end
-         else
-           Proc.new do
-             SignalThread.wait(strsig)
-             block.call
-           end
-         end
 
-    self.new(pr) do |pr|
-      pr.call
+    if options[:detailed]
+      self.new(block) do |pr|
+        info = SignalThread.waitinfo(strsig)
+        pr.call(info)
+      end
+    else
+      self.new(block) do |pr|
+        SignalThread.wait(strsig)
+        pr.call
+      end
     end
   end
 


### PR DESCRIPTION
At current mruby master, some of build broken.

* mruby changed its internal struct. fix in https://github.com/mattn/mruby-thread/pull/49
* some of test cases failed in mruby-timer-thread

This patch fixes all of.