### PR TITLE
Reset sigmask in SignalThread#cancel

### DIFF
--- a/src/mrb_signalthread.c
+++ b/src/mrb_signalthread.c
@@ -454,11 +454,17 @@ static mrb_value mrb_signal_thread_exception(mrb_state *mrb, mrb_value self)
 static mrb_value mrb_signal_thread_cancel(mrb_state *mrb, mrb_value self)
 {
   mrb_thread_context *context = mrb_signal_thread_context(mrb, self);
+  sigset_t set;
   if (context->mrb == NULL) {
     return mrb_false_value();
   }
 
   if (context->alive) {
+    /* reset sigmask */
+    sigemptyset(&set);
+    if (pthread_sigmask(SIG_SETMASK, &set, NULL) != 0)
+      mrb_raise(mrb, E_RUNTIME_ERROR, "set mask error");
+
     if (pthread_cancel(context->thread) != 0) {
       mrb_raise(mrb, E_RUNTIME_ERROR, "pthread_cancel failed");
     }


### PR DESCRIPTION
Hi @pyama86 

Calling #cancel does not correctly reset the sigmask.
So if you call SignalThread.trap multiple times, the signal will not be processed correctly.

Steps to reproduce:

signal_test.rb
```ruby
# require "mruby-process"
# require "haconiwa/mruby-exec"
def exec
  pid = Process.fork do
    Exec.execve_override_procname(ENV.to_hash, "sleep", "/bin/sleep", "10")
  end
  puts "sleep(pid: #{pid})"

  th = SignalThread.trap(:INT, {detailed:true}) do |info|
    puts "SIGINT pid: #{pid} siginfo.uid:#{info.uid} siginfo.pid:#{info.pid}"
  end

  Process.waitpid(pid)

  th.cancel
end

exec
exec
```

Execution result(🌟 is a comment)
```
❯ mruby signal_test.rb
sleep(pid: 299140)  🌟 Press Ctrl-C
^CSIGINT pid: 299140 siginfo.uid:0 siginfo.pid:0 🌟 The first sleep command ends.
sleep(pid: 299143)  🌟 Press Ctrl-C
^CSIGINT pid: 299143 siginfo.uid:0 siginfo.pid:0 🌟 SIGINT is trapped but sleep command never ends.
^CSIGINT pid: 299143 siginfo.uid:0 siginfo.pid:0
^CSIGINT pid: 299143 siginfo.uid:0 siginfo.pid:0
```